### PR TITLE
Refactor SLAMDataset, speed up mesh visualization, and various minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pixi run all
 ```
 You can optionally add arguments to all commands by settings `NGM_EXTRA_ARGS` prior to running the command. For example, to run all datasets with visualization enabled run:
 ```bash
-NGM_EXTRA_ARGS="--rerun_vis True" pixi run all
+NGM_EXTRA_ARGS="--rerun_vis True --rerun_save True" pixi run all
 ```
 
 ### Manual

--- a/src/neural_graph_mapping/config/neural_graph_map.yaml
+++ b/src/neural_graph_mapping/config/neural_graph_map.yaml
@@ -43,7 +43,7 @@ block_size: 3000000
 preview_res_factor: 0.3
 render_frames: []
 render_frame_freq: 200  # every Nth frame we render some images
-extract_mesh_frame_freq: 25 # every Nth frame we extract the mesh
+extract_mesh_frame_freq: 100 # every Nth frame we extract the mesh
 extract_mesh_frames: []  # specific frames at which to extract mesh
 extract_mesh_fields: []  # specific fields to extract mesh from
 log_iteration_freq: 100  # every Nth iteration 

--- a/src/neural_graph_mapping/config/scannet_dataset.yaml
+++ b/src/neural_graph_mapping/config/scannet_dataset.yaml
@@ -1,6 +1,6 @@
 dataset_type: neural_graph_mapping.slam_datasets.scannet_dataset.ScanNetDataset
 dataset_config:
-  root_dir: ~/.neural_graph_mapping/datasets/scannet_subset/
+  root_dir: ~/.neural_graph_mapping/datasets/scannet/
   slam_final_file: orbslam2_final.txt
   slam_c2w_file: orbslam2_c2w.json
   slam_pg_file: orbslam2_pg.json


### PR DESCRIPTION
This PR adds a new function to retrieve all available scenes for a dataset (required for another project). For this `root_dir` and `scene` have been moved into to the SLAMDataset from the derived classes.

Also changes a few other things:
- Fix visualization always saving instead of showing the viewer by default (now `--rerun_vis True` will show the viewer and `---rerun_vis True --rerun_save True` will save)
- Side-steps Open3D mesh creation (previously used to simplify mesh; however, I believe this is not needed with recent Rerun versions anymore and it is quite slow; directly logging to Rerun now)
- Remove `--rerun-white-background` as this is supported in the viewer now